### PR TITLE
feat: add a new project

https://github.com/oglimmer/irl-planner-p

### DIFF
--- a/data/projects.ts
+++ b/data/projects.ts
@@ -7,6 +7,15 @@ export interface Project {
 
 export const projects: Project[] = [
   {
+    title: "ID5 IRL Attendance App",
+    text: "A web app for collecting attendee information ahead of company offsites (\"IRLs\"). Admins (IRL team) configure an event once; employees sign in with Google SSO (restricted to @oglimmer.com) and submit attendance + travel details via a form with conditional logic. The app tracks non-responders, sends invitations + tz-aware reminders over email or Slack, logs all activity, and exports responses. Events can carry a cover image, and the admin activity timeline is filterable by participant vs. admin actions.",
+    linkData: [
+      ["https://irl-planner.oglimmer.com/", "Web"],
+      ["https://github.com/oglimmer/irl-planner-pro", "source code"]
+    ],
+    techList: "[Go, Vue, TypeScript, Shell, CSS, Go Template]"
+  },
+  {
     title: "Coding Agent - Self-Service Feature Development Platform",
     text: "Self-service platform where authenticated users request features against configured GitHub repositories and an autonomous coding agent implements them end-to-end — with tests — opens a pull request, waits for the repository's GitHub Action review, and fixes the findings. It then auto-merges the approved PR, or — if the requester turns auto-merge off — stops at an approved, green PR and leaves the final merge to a human.",
     linkData: [

--- a/tests/projects.spec.ts
+++ b/tests/projects.spec.ts
@@ -5,6 +5,45 @@ function findProject(title: string, list: Project[]): Project | undefined {
   return list.find(p => p.title === title)
 }
 
+describe('Data: ID5 IRL Attendance App project', () => {
+  const irlPlannerProject = findProject('ID5 IRL Attendance App', projects)
+
+  it('is present in the projects array', () => {
+    expect(irlPlannerProject !== undefined).toBe(true)
+  })
+
+  it('has the correct title', () => {
+    expect(irlPlannerProject!.title).toBe('ID5 IRL Attendance App')
+  })
+
+  it('has two links', () => {
+    expect(irlPlannerProject!.linkData.length).toBe(2)
+  })
+
+  it('has the Web link to irl-planner.oglimmer.com', () => {
+    const webLink = irlPlannerProject!.linkData.find(([, label]) => label === 'Web')
+    expect(webLink !== undefined).toBe(true)
+    expect(webLink![0]).toBe('https://irl-planner.oglimmer.com/')
+  })
+
+  it('has the source code link to the GitHub repo', () => {
+    const sourceLink = irlPlannerProject!.linkData.find(([, label]) => label === 'source code')
+    expect(sourceLink !== undefined).toBe(true)
+    expect(sourceLink![0]).toBe('https://github.com/oglimmer/irl-planner-pro')
+  })
+
+  it('lists the technologies from the repository', () => {
+    expect(irlPlannerProject!.techList).toBe('[Go, Vue, TypeScript, Shell, CSS, Go Template]')
+  })
+
+  it('mentions Google SSO, offsites, and conditional logic in the description', () => {
+    const text = irlPlannerProject!.text
+    expect(text.includes('Google SSO')).toBe(true)
+    expect(text.includes('offsites')).toBe(true)
+    expect(text.includes('conditional logic')).toBe(true)
+  })
+})
+
 describe('Data: coding-agent project', () => {
   const codingAgentProject = findProject('Coding Agent - Self-Service Feature Development Platform', projects)
 


### PR DESCRIPTION
Automated change created by the coding-agent platform.

Feature request:

add a new project

https://github.com/oglimmer/irl-planner-pro

https://irl-planner.oglimmer.com/


ID5 IRL Attendance App

A web app for collecting attendee information ahead of company offsites ("IRLs"). Admins (IRL team) configure an event once; employees sign in with Google SSO (restricted to @oglimmer.com) and submit attendance + travel details via a form with conditional logic. The app tracks non-responders, sends invitations + tz-aware reminders over email or Slack, logs all activity, and exports responses. Events can carry a cover image, and the admin activity timeline is filterable by participant vs. admin actions.


Go 52.2%
Vue 29.1%
TypeScript 11.8%
Shell 3.9%
CSS 2.0%
Go Template 0.6%
Other 0.4%

Implemented by Claude Code (deepseek-v4-pro, deepseek backend). This PR will be
reviewed by the repository's GitHub Action; findings are addressed automatically
before merge.